### PR TITLE
Add missing ios frameworks to plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,5 +44,7 @@
       <header-file src="src/ios/Main.h" target-dir="Razorpay"/>
       <source-file src="src/ios/Main.m" target-dir="Razorpay"/>
       <framework src="src/ios/Razorpay.framework" custom="true" />
+      <framework src="CoreTelephony.framework" />
+      <framework src="SystemConfiguration.framework" />
   </platform>
 </plugin>


### PR DESCRIPTION
Project fails to build on ios without adding these frameworks.

Fixes #8